### PR TITLE
add From implementation to GamepadId so that id can be used for indexing etc

### DIFF
--- a/src/backend/gilrs.rs
+++ b/src/backend/gilrs.rs
@@ -8,6 +8,12 @@ use crate::Result;
 
 pub type ImplementationId = gilrs::GamepadId;
 
+impl From<&GamepadId> for usize {
+    fn from(id: &GamepadId) -> Self {
+        id.0.into()
+    }
+}
+
 pub enum OwnedImplementationGamepad {}
 
 pub struct ImplementationContext {

--- a/src/backend/sdl2.rs
+++ b/src/backend/sdl2.rs
@@ -8,6 +8,12 @@ use crate::Result;
 
 pub type ImplementationId = u32;
 
+impl From<&GamepadId> for usize {
+    fn from(id: &GamepadId) -> Self {
+        id.0 as usize
+    }
+}
+
 pub struct OwnedImplementationGamepad(sdl2::controller::GameController);
 
 pub struct ImplementationContext {


### PR DESCRIPTION
This adds a `From<&GamepadId>` implementation to `usize` so that we can use the index to look up sets of gamepad button mappings, among other things.